### PR TITLE
Optimise circuits

### DIFF
--- a/crates/zk-commit-core/src/claim_circuit.rs
+++ b/crates/zk-commit-core/src/claim_circuit.rs
@@ -22,7 +22,6 @@ pub struct ClaimTargets {
     pub nullifier_hash: HashOutTarget,
     pub commitment: HashOutTarget,
     pub siblings: Vec<HashOutTarget>,
-    pub own_leaf_hash: HashOutTarget,
     pub index_target: Target,
 }
 
@@ -55,11 +54,9 @@ pub fn generate_claim_circuit(
     // Create the commitment hash target
     let commitment: HashOutTarget = builder.add_virtual_hash_public_input();
 
-    // Calculate my own leaf hash and verify it is correctly calculated
+    // Calculate my own leaf hash 
     let inputs = vec![vec![amount], nullifier_hash.elements.to_vec(), vec![secret]].concat();
-    let own_leaf_hash_calculated = get_hash_from_input_targets_circuit(builder, inputs);
-    let own_leaf_hash = builder.add_virtual_hash();
-    builder.connect_hashes(own_leaf_hash_calculated, own_leaf_hash);
+    let own_leaf_hash = get_hash_from_input_targets_circuit(builder, inputs);
 
     // Verify the merkle proof of the leaf we calculated
     let mut siblings: Vec<HashOutTarget> = Vec::new();
@@ -81,7 +78,6 @@ pub fn generate_claim_circuit(
         nullifier_hash,
         commitment,
         siblings,
-        own_leaf_hash,
         index_target,
     }
 }
@@ -96,7 +92,6 @@ pub fn set_claim_circuit(
     pw.set_target(claim_targets.secret, claim_proving_inputs.pair.get_secret());
     pw.set_hash_target(claim_targets.commitment, claim_proving_inputs.commitment);
     pw.set_hash_target(claim_targets.nullifier_hash, claim_proving_inputs.nullifier_hash);
-    pw.set_hash_target(claim_targets.own_leaf_hash, claim_proving_inputs.own_leaf_hash);
 
     pw.set_target(claim_targets.index_target, claim_proving_inputs.index);
 

--- a/crates/zk-commit-core/src/claim_execution.rs
+++ b/crates/zk-commit-core/src/claim_execution.rs
@@ -9,7 +9,6 @@ pub struct ClaimProvingInputs {
     pub commitment: HashOut<F>,
     pub commitment_merkle_proof: Vec<HashOut<F>>,
     pub nullifier_hash: HashOut<F>,
-    pub own_leaf_hash: HashOut<F>,
     pub index: F,
 }
 
@@ -32,13 +31,11 @@ impl Claim {
 
 pub fn execute_claim(claim: Claim) -> ClaimProvingInputs {
     let nullifier_hash = claim.get_nullifier_hash();
-    let own_leaf_hash = claim.get_hash();
     ClaimProvingInputs {
         pair: claim.pair,
         commitment: claim.commitment,
         commitment_merkle_proof: claim.commitment_merkle_proof,
         nullifier_hash,
-        own_leaf_hash,
         index: F::from_canonical_u64(claim.index as u64),
     }
 }


### PR DESCRIPTION
Remove verification of own hash since if we
1. Verify nullifier hash is correctly calculated -> Implies secret and amount are correct
2. Nullifier Hash is a public input 

We can assume that the own leaf hash is correctly calculated since it is composed of nullifier hash, amount and secret. Thus we do not need to do that check.