### PR TITLE
Fix circuit config num_wires

### DIFF
--- a/crates/zk-commit-core/src/circuit_config.rs
+++ b/crates/zk-commit-core/src/circuit_config.rs
@@ -9,7 +9,7 @@ pub const COMMITMENT_TREE_DEPTH: usize = 4;
 pub const NUM_LEAVES_MERKLE_TREE: usize = 1 << (COMMITMENT_TREE_DEPTH - 1);
 
 pub const STANDARD_CONFIG: CircuitConfig = CircuitConfig {
-    num_wires: 170,
+    num_wires: 135,
     num_routed_wires: 80,
     num_constants: 2,
     use_base_arithmetic_gate: true,


### PR DESCRIPTION
STANDARD_CONFIG num_wires should be 135

History:
In order to support some EC operations inside circuit, I changed it from 135 to 170 in zkpay repo.